### PR TITLE
HAE-275: move llm definition to config

### DIFF
--- a/config/schema/iq_text_generator.settings.yml
+++ b/config/schema/iq_text_generator.settings.yml
@@ -1,3 +1,5 @@
 base_url: ''
 generate_endpoint: ''
 timeout: 120
+llm: 'Gemini 2.5 Pro'
+generation_steps: 2

--- a/src/Form/TextGeneratorSettingsForm.php
+++ b/src/Form/TextGeneratorSettingsForm.php
@@ -54,6 +54,22 @@ class TextGeneratorSettingsForm extends ConfigFormBase implements ContainerInjec
       '#required' => TRUE,
     ];
 
+    $form['llm'] = [
+      '#type' => 'textfield',
+      '#default_value' => $settings->get('llm') ?? 'Gemini 2.5 Pro',
+      '#title' => $this->t('Language Model'),
+      '#description' => $this->t('Specify the language model to use.'),
+      '#required' => TRUE,
+    ];
+
+    $form['generation_steps'] = [
+      '#type' => 'number',
+      '#default_value' => $settings->get('generation_steps') ?? 2,
+      '#title' => $this->t('Generational Steps'),
+      '#description' => $this->t('Number of generational steps.'),
+      '#required' => TRUE,
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -67,6 +83,9 @@ class TextGeneratorSettingsForm extends ConfigFormBase implements ContainerInjec
     $config->set('base_url', $form_state->getValue('base_url'));
     $config->set('generate_endpoint', $form_state->getValue('generate_endpoint'));
     $config->set('timeout', $form_state->getValue('timeout'));
+    $config->set('llm', $form_state->getValue('llm'));
+    $config->set('generation_steps', $form_state->getValue('generation_steps'));
+
     $config->save();
 
     parent::submitForm($form, $form_state);

--- a/src/Plugin/Field/FieldWidget/GeneratedTextWidget.php
+++ b/src/Plugin/Field/FieldWidget/GeneratedTextWidget.php
@@ -82,8 +82,6 @@ class GeneratedTextWidget extends StringTextareaWidget {
     $defaults += [
       'persona' => 'Neutral',
       'output_type' => 'blog',
-      'llm_model_name' => 'Gemini 2.5 PRO',
-      'generation_steps' => '2',
     ];
 
     return $defaults;
@@ -127,32 +125,6 @@ class GeneratedTextWidget extends StringTextareaWidget {
       '#required' => TRUE,
     ];
 
-    $element['llm_model_name'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Language model'),
-      '#default_value' => $this->getSetting('llm_model_name'),
-      '#options' => [
-        'Gemini 2.5 PRO' => $this->t('Gemini 2.5 PRO'),
-        'Gemini 2.0 Flash' => $this->t('Gemini 2.0 Flash'),
-        'Gemini 1.5 PRO' => $this->t('Gemini 1.5 PRO'),
-        'Gemini 1.5 Flash' => $this->t('Gemini 1.5 Flash'),
-        'Gemini 1.0 PRO' => $this->t('Gemini 1.0 PRO'),
-        'Palm 2' => $this->t('Palm 2'),
-      ],
-      '#required' => TRUE,
-    ];
-
-    $element['generation_steps'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Generational Steps'),
-      '#default_value' => $this->getSetting('generation_steps'),
-      '#options' => [
-        '1' => '1',
-        '2' => '2',
-      ],
-      '#required' => TRUE,
-    ];
-
     return $element;
   }
 
@@ -163,8 +135,6 @@ class GeneratedTextWidget extends StringTextareaWidget {
     $summary = parent::settingsSummary();
     $summary[] = $this->t('Persona: @persona', ['@persona' => $this->getSetting('persona')]);
     $summary[] = $this->t('Output type: @type', ['@type' => $this->getSetting('output_type')]);
-    $summary[] = $this->t('Language model: @model', ['@model' => $this->getSetting('llm_model_name')]);
-    $summary[] = $this->t('Generational steps: @steps', ['@steps' => $this->getSetting('generation_steps')]);
 
     return $summary;
   }
@@ -227,8 +197,6 @@ class GeneratedTextWidget extends StringTextareaWidget {
       'parameters' => [],
       'languages' => [$this->getLanguage()['name']],
       'output_type' => $this->getSetting('output_type'),
-      'generation_steps' => $this->getSetting('generation_steps'),
-      'llm_selection' => $this->getSetting('llm_model_name'),
     ];
     $this->moduleHandler->alter('iq_text_generator_inputs', $inputs, $element, $form_state);
     return $inputs;

--- a/src/Service/TextGenerator.php
+++ b/src/Service/TextGenerator.php
@@ -73,6 +73,8 @@ class TextGenerator implements TextGeneratorInterface {
    */
   public function generateText(array $inputs) {
     $this->establishConnection();
+    $inputs['llm_selection'] = $this->config->get('llm');
+    $inputs['generation_steps'] = $this->config->get('generation_steps');
     $response = $this->sendRequest('POST', $this->config->get('generate_endpoint'), [
       'json' => $inputs,
     ]);


### PR DESCRIPTION
This PR moves the definition of the language model and the generation steps to the global configuration of the module instead of each widget to allow update without additional release.